### PR TITLE
Bug fix: Event loop is closed

### DIFF
--- a/bitcoin_nostr_chat/async_thread.py
+++ b/bitcoin_nostr_chat/async_thread.py
@@ -117,7 +117,10 @@ class AsyncThread(QThread):
             self.task_queue.put_nowait((coro_func, on_done))
 
         # Schedule the queue put in a thread-safe manner.
-        self.loop.call_soon_threadsafe(put_item)
+        if not self.loop.is_closed():
+            self.loop.call_soon_threadsafe(put_item)
+        else:
+            logger.warning("Event loop is closed; cannot schedule tasks anymore.")
 
     def run_coroutine_parallel(self, coro_func: Awaitable, callback=None):
         """


### PR DESCRIPTION
Resolving this error:
```
raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```